### PR TITLE
c.DATRASraw: Avoid losing names(dimnames(Nage))

### DIFF
--- a/DATRAS/R/read_datras.R
+++ b/DATRAS/R/read_datras.R
@@ -286,6 +286,9 @@ c.DATRASraw <- function(...){
   args <- list(...)
   testUniqueHaulID(args)
   args <- lapply(args,unclass) ## because do_mapply dispatch on length
+  ## rbind loses names(dimnames(.)). Get names from 1st argument (NULL if missing object):
+  N.ndn    <- names(dimnames(args[[1]][["HH"]][["N"]]))
+  Nage.ndn <- names(dimnames(args[[1]][["HH"]][["Nage"]]))
   ## Add missing variable names with warning
   argnames <- Map(Map,list("names"),args)
   union <- function(...)unique(c(...))
@@ -312,6 +315,9 @@ c.DATRASraw <- function(...){
   ## Note that rbind drops all zero-row data.frames - hence levels of zero-length
   ## factor will be dropped. Have to fix this:
   ans <- refactorHaulLevels(ans)
+  ## rbind loses names(dimnames(.)). Re-assign from 1st argument (NULL allowed):
+  names(dimnames(ans[["HH"]][["N"]])) <- N.ndn
+  names(dimnames(ans[["HH"]][["Nage"]])) <- Nage.ndn
   class(ans) <- "DATRASraw"
   ans
 }


### PR DESCRIPTION
Not critical - just inconvenient:

```r
x <- readExchange( system.file("exchange","Exchange1.zip",package="DATRAS") )
x <- subset(x, Species=="Gadus morhua")
x <- addSpectrum(x)
spl <- split(x, x$Month)
names(dimnames(spl[[1]]$N)) ## OK
spl <- lapply(spl, addNage, ages=0:3)
names(dimnames(spl[[1]]$Nage)) ## OK
z <- do.call("c", spl)
names(dimnames(z$Nage)) ## oops - lost !
names(dimnames(z$N)) ## oops - lost !
df <- as.data.frame(z, response="Nage") ## Warning: Response matrix does not have a named column dimension (e.g. ageGroup or sizeGroup)
```
