### PR TITLE
Make explicit calls to maps::map and mapdata::worldHires

### DIFF
--- a/DATRAS/R/read_datras.R
+++ b/DATRAS/R/read_datras.R
@@ -718,8 +718,8 @@ plot.DATRASraw <- function(x,add=FALSE,pch=16,
   }
   if(plot.points)points(x$lon,x$lat,pch=pch,...)
   if(plot.map){
-    ok <- require(maps) && require(mapdata)
-    if(ok)map("worldHires",add=TRUE,lwd=1,col="darkgrey",fill=FALSE)
+    ok <- requireNamespace("maps", quietly = TRUE) && requireNamespace("mapdata", quietly = TRUE)
+    if(ok) maps::map("mapdata::worldHires",add=TRUE,lwd=1,col="darkgrey",fill=FALSE)
   }
   if(plot.response){
     response <- which(sapply(x[[2]],is.matrix))[1]


### PR DESCRIPTION
The function `plot.DATRASraw` was attaching the namespaces of the two packages and was calling the function `map`. This can lead to problems when a function named map is defined before plotting a DATRASraw object (e.g. `purrr` package) .

Wtih this PR, the function is checking if the namespaces are available and calls explicitly the the function and location of the map data, without requiring the packages.